### PR TITLE
Fix agent notes serialization

### DIFF
--- a/dotnet-eark-sip/src/Impl/EARK/EARKMETSCreator.cs
+++ b/dotnet-eark-sip/src/Impl/EARK/EARKMETSCreator.cs
@@ -371,13 +371,16 @@ public abstract class EARKMETSCreator
             Othertype = ipAgent.GetOtherType(),
         };
 
-        MetsTypeMetsHdrAgentNote note = new MetsTypeMetsHdrAgentNote
+        if (!string.IsNullOrEmpty(ipAgent.GetNote()))
         {
-            Value = ipAgent.GetNote(),
-            Notetype = ipAgent.GetNoteType() ?? Notetype.NOT_SET
-        };
+            var note = new MetsTypeMetsHdrAgentNote
+            {
+                Value = ipAgent.GetNote(),
+                Notetype = ipAgent.GetNoteType()
+            };
+            agent.Note.Add(note);
+        }
 
-        agent.Note.Add(note);
         return agent;
     }
 

--- a/dotnet-eark-sip/src/Model/IP/IPAgent.cs
+++ b/dotnet-eark-sip/src/Model/IP/IPAgent.cs
@@ -15,7 +15,7 @@ namespace IP
         private MetsTypeMetsHdrAgentType type;
         private string? otherType;
         private string note;
-        private Notetype? noteType;
+        private Notetype noteType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IPAgent"/> class with default values.
@@ -38,7 +38,7 @@ namespace IP
         /// <param name="otherType">The other type of the agent, if applicable.</param>
         /// <param name="note">The note associated with the agent.</param>
         /// <param name="noteType">The type of the note.</param>
-        public IPAgent(string name, MetsTypeMetsHdrAgentRole role, string? otherRole, MetsTypeMetsHdrAgentType type, string? otherType, string note, Notetype noteType)
+        public IPAgent(string name, MetsTypeMetsHdrAgentRole role, string? otherRole, MetsTypeMetsHdrAgentType type, string? otherType, string note, Notetype? noteType)
         {
             this.name = name;
             this.role = role;
@@ -46,7 +46,7 @@ namespace IP
             this.type = type;
             this.otherType = otherType;
             this.note = note;
-            this.noteType = noteType;
+            this.noteType = noteType ?? Notetype.NOT_SET;
         }
 
         public string GetName()
@@ -115,23 +115,20 @@ namespace IP
             return this;
         }
 
-        public Notetype? GetNoteType()
+        public Notetype GetNoteType()
         {
             return noteType;
         }
 
         public IPAgent SetNoteType(Notetype? noteType)
         {
-            this.noteType = noteType;
+            this.noteType = noteType ?? Notetype.NOT_SET;
             return this;
         }
 
         private string GetNoteTypeString()
         {
-            Notetype value = noteType ?? Notetype.IDENTIFICATIONCODE;
-
-            if (noteType == null) return "";
-            else return EnumUtils.GetXmlEnumName(value);
+            return EnumUtils.GetXmlEnumName(noteType);
         }
 
         public override string ToString()

--- a/dotnet-eark-sip/src/Model/Mets/MetsTypeMetsHdrAgentNote.cs
+++ b/dotnet-eark-sip/src/Model/Mets/MetsTypeMetsHdrAgentNote.cs
@@ -37,6 +37,13 @@ namespace Mets
         [System.Xml.Serialization.XmlAttributeAttribute("NOTETYPE", Namespace = "https://DILCIS.eu/XML/METS/CSIPExtensionMETS", Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
         public global::Xml.Mets.CsipExtensionMets.Notetype Notetype { get; set; }
 
+        /// <summary>
+        /// <para xml:lang="en">Gets a value indicating whether the Notetype property is specified.</para>
+        /// <remarks>This property is true if the Notetype property is not equal to NOT_SET; otherwise, it is false.</remarks>
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool NotetypeSpecified => this.Notetype != global::Xml.Mets.CsipExtensionMets.Notetype.NOT_SET;
+
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         private System.Collections.ObjectModel.Collection<System.Xml.XmlAttribute> _anyAttribute;
 


### PR DESCRIPTION
This pull request addresses an issue with the serialization of the not_set agent notetype. The following changes were made:
- Updated EARKMETSCreator.cs to handle the agent notes correctly during serialization.
- Refactored IPAgent.cs to improve notetype handling and ensure proper serialization logic.
- Added logic in MetsTypeMetsHdrAgentNote.cs to support the correct representation of the not_set notetype.

Files changed:
- [EARKMETSCreator.cs](https://github.com/igfej-justica-gov-pt/dotnet-eark-sip/blob/main/dotnet-eark-sip/src/Impl/EARK/EARKMETSCreator.cs)
- [IPAgent.cs](https://github.com/igfej-justica-gov-pt/dotnet-eark-sip/blob/main/dotnet-eark-sip/src/Model/IP/IPAgent.cs)
- [MetsTypeMetsHdrAgentNote.cs](https://github.com/igfej-justica-gov-pt/dotnet-eark-sip/blob/main/dotnet-eark-sip/src/Model/Mets/MetsTypeMetsHdrAgentNote.cs)

Motivation:
Ensures that agents with a not_set notetype are serialized as expected, improving standards compliance.